### PR TITLE
fix: issue-102 - increaseLock _receiver

### DIFF
--- a/contracts/TimeLockPool.sol
+++ b/contracts/TimeLockPool.sol
@@ -200,7 +200,7 @@ contract TimeLockPool is BasePool, ITimeLockPool {
             revert ZeroAmountError();
         }
 
-        Deposit memory userDeposit = depositsOf[_msgSender()][_depositId];
+        Deposit memory userDeposit = depositsOf[_receiver][_depositId];
 
         // Only can extend if it has not expired
         if (block.timestamp >= userDeposit.end) {


### PR DESCRIPTION
[#102](https://github.com/sherlock-audit/2022-10-merit-circle-judging/issues/102) increaseLock() should read userDeposit[_receiver] instead of depositsOf[_msgSender()]