### PR TITLE
fix: issue-103 - pointsPerShare manupulation

### DIFF
--- a/test/TimeLockPool.ts
+++ b/test/TimeLockPool.ts
@@ -171,6 +171,10 @@ describe("TimeLockPool", function () {
 
         const DEPOSIT_AMOUNT = parseEther("10");
 
+        it("First deposit should not be less than 1e18", async() => {
+            await expect(timeLockPool.deposit(parseEther("0.1"), 0, account3.address)).to.be.revertedWith("SmallFirstDepositError");
+        });
+        
         it("Depositing with no lock should lock it for 10 minutes to prevent flashloans", async() => {
             await timeLockPool.deposit(DEPOSIT_AMOUNT, 0, account3.address);
             const MIN_LOCK_DURATION = await timeLockPool.MIN_LOCK_DURATION();


### PR DESCRIPTION
[#103](https://github.com/sherlock-audit/2022-10-merit-circle-judging/issues/103) First user can inflate pointsPerShare and cause _correctPoints() to revert due to overflow