### PR TITLE
fix: issue-106 - minimum lock of 1 day

### DIFF
--- a/contracts/TimeLockPool.sol
+++ b/contracts/TimeLockPool.sol
@@ -19,7 +19,7 @@ contract TimeLockPool is BasePool, ITimeLockPool {
 
     uint256 public maxBonus;
     uint256 public maxLockDuration;
-    uint256 public constant MIN_LOCK_DURATION = 10 minutes;
+    uint256 public constant MIN_LOCK_DURATION = 1 days;
     
     uint256[] public curve;
     uint256 public unit;


### PR DESCRIPTION
[#106](https://github.com/sherlock-audit/2022-10-merit-circle-judging/issues/106) Front run distributeRewards() can steal the newly added rewards