### PR TITLE
fix: issue-108 - kick function

### DIFF
--- a/contracts/TimeLockPool.sol
+++ b/contracts/TimeLockPool.sol
@@ -335,4 +335,18 @@ contract TimeLockPool is BasePool, ITimeLockPool {
         }
         emit CurveChanged(_msgSender());
     }
+
+    function kick(uint256 _depositId, address _user) external {
+        if (_depositId >= depositsOf[_user].length) {
+            revert NonExistingDepositError();
+        }
+        Deposit memory userDeposit = depositsOf[_user][_depositId];
+        if (block.timestamp < userDeposit.end) {
+            revert TooSoonError();
+        }
+
+        // burn pool shares so that resulting are equal to deposit amount
+        _burn(_user, userDeposit.shareAmount - userDeposit.amount);
+        depositsOf[_user][_depositId].shareAmount =  userDeposit.amount;
+    }    
 }


### PR DESCRIPTION
[#108](https://github.com/sherlock-audit/2022-10-merit-circle-judging/issues/108) Expired locks should not continue to earn rewards at the original high multiplier rate