### PR TITLE
fix: issue-109 - prevent share burning

### DIFF
--- a/contracts/TimeLockPool.sol
+++ b/contracts/TimeLockPool.sol
@@ -16,6 +16,7 @@ contract TimeLockPool is BasePool, ITimeLockPool {
     error NonExistingDepositError();
     error TooSoonError();
     error MaxBonusError();
+    error ShareBurningError();
 
     uint256 public maxBonus;
     uint256 public maxLockDuration;
@@ -169,13 +170,12 @@ contract TimeLockPool is BasePool, ITimeLockPool {
         // Multiplier curve changes with time, need to check if the mint amount is bigger, equal or smaller than the already minted
         
         // If the new amount if bigger mint the difference
-        if (mintAmount > userDeposit.shareAmount) {
+        if (mintAmount >= userDeposit.shareAmount) {
             depositsOf[_msgSender()][_depositId].shareAmount =  mintAmount;
             _mint(_msgSender(), mintAmount - userDeposit.shareAmount);
         // If the new amount is less then burn that difference
-        } else if (mintAmount < userDeposit.shareAmount) {
-            depositsOf[_msgSender()][_depositId].shareAmount =  mintAmount;
-            _burn(_msgSender(), userDeposit.shareAmount - mintAmount);
+        } else {
+            revert ShareBurningError();
         }
 
         depositsOf[_msgSender()][_depositId].start = uint64(block.timestamp);

--- a/test/TimeLockPool.ts
+++ b/test/TimeLockPool.ts
@@ -842,7 +842,7 @@ describe("TimeLockPool", function () {
             expect(theoreticalEndShareAmount).to.be.eq(endUserDepostit.shareAmount).to.be.eq(endBalance);
         });
 
-        it("Extending lock with a significant smaller new curve should burn tokens", async() => {
+        it("Extending lock that mints less shares that the user has should revet", async() => {
             // First deposit calculated with multiplier from first curve
             // Then curve changes and multiplier gets smaller, generating a net burn in the tokens
             // Amount * Multiplier1 > Amount * Multiplier2
@@ -858,21 +858,7 @@ describe("TimeLockPool", function () {
 
             await timeTraveler.setNextBlockTimestamp(nextBlockTimestamp);
 
-            await expect(timeLockPool.extendLock(0, THREE_MONTHS * 2))
-                .to.emit(timeLockPool, "Transfer")
-
-            const endUserDepostit = await timeLockPool.depositsOf(account1.address, 0);
-            const endBalance = await timeLockPool.balanceOf(account1.address);
-
-            expect(startBalance).to.be.eq(startUserDepostit.shareAmount)
-            expect(endBalance).to.be.eq(endUserDepostit.shareAmount)
-            
-            const latestBlockTimestamp = (await hre.ethers.provider.getBlock("latest")).timestamp;
-            const sixMonthsMultiplier = await timeLockPool.getMultiplier(startUserDepostit.end.sub(latestBlockTimestamp).add(THREE_MONTHS * 2));
-            const theoreticalEndShareAmount = DEPOSIT_AMOUNT.mul(sixMonthsMultiplier).div(parseEther("1"));
-
-            expect(theoreticalEndShareAmount).to.be.eq(endUserDepostit.shareAmount).to.be.eq(endBalance);
-            expect(endBalance).to.be.below(startBalance)
+            await expect(timeLockPool.extendLock(0, THREE_MONTHS * 2)).to.be.revertedWith("ShareBurningError");
         });
     });
 

--- a/test/Upgradeable.ts
+++ b/test/Upgradeable.ts
@@ -284,7 +284,7 @@ describe("TimeLockPool", function () {
                 const nextBlockTimestamp = (startUserDepostit.end.sub(startUserDepostit.start)).div(2).add(startUserDepostit.start).toNumber();
                 // Fastforward to half of the deposit time elapsed
                 await timeTraveler.setNextBlockTimestamp(nextBlockTimestamp);
-                await timeLockNonTransferablePool.extendLock(0, MAX_LOCK_DURATION / 24)
+                await timeLockNonTransferablePool.extendLock(0, MAX_LOCK_DURATION / 12)
     
                 let slot: string[] = new Array;
                 for(let i = 0; i < 1000; i++) {
@@ -366,7 +366,7 @@ describe("TimeLockPool", function () {
                 const nextBlockTimestamp = (startUserDepostit.end.sub(startUserDepostit.start)).div(2).add(startUserDepostit.start).toNumber();
                 // Fastforward to half of the deposit time elapsed
                 await timeTraveler.setNextBlockTimestamp(nextBlockTimestamp);
-                await timeLockNonTransferablePool.extendLock(0, MAX_LOCK_DURATION / 24)
+                await timeLockNonTransferablePool.extendLock(0, MAX_LOCK_DURATION / 12)
     
                 // Upgrade
                 const timeLockNonTransferablePoolFactoryV2 = new TimeLockNonTransferablePoolV2__factory(deployer);


### PR DESCRIPTION
[#109](https://github.com/sherlock-audit/2022-10-merit-circle-judging/issues/109) Extend lock period should never result in a decrease of overall rewards (total length of locked period * shares)